### PR TITLE
Remove `gec_*` shims

### DIFF
--- a/Formula/git_events_collector.rb
+++ b/Formula/git_events_collector.rb
@@ -107,12 +107,6 @@ class GitEventsCollector < Formula
   def shell_bin
     %w[
       gec
-      gec_path
-      gec_path_active
-      gec_path_data_dir
-      gec_rotate
-      gec_run
-      gec_tsv-to-sqlite
     ]
   end
 end


### PR DESCRIPTION
They're no longer in the tarball, so we shouldn't be trying to install them.